### PR TITLE
Help Permissions Implemented

### DIFF
--- a/.vs/DiscordBot/xs/UserPrefs.xml
+++ b/.vs/DiscordBot/xs/UserPrefs.xml
@@ -1,13 +1,14 @@
 ﻿<Properties StartupConfiguration="{1F84D78C-D248-4DB7-8A19-88CD9A33D51A}|Default">
-  <MonoDevelop.Ide.Workbench ActiveDocument="DiscordBot/Modules/UserCustomization.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="DiscordBot/Modules/AdminUtility/LogHandler.cs">
     <Files>
-      <File FileName="DiscordBot/Modules/AdminUtility/AdminUtilities.cs" Line="23" Column="10" />
-      <File FileName="DiscordBot/Modules/AdminUtility/LogHandler.cs" Line="50" Column="79" />
-      <File FileName="DiscordBot/Core/BotUtils.cs" Line="92" Column="1" />
+      <File FileName="DiscordBot/Core/BotUtils.cs" Line="74" Column="42" />
       <File FileName="DiscordBot/Core/CommandHandler.cs" Line="25" Column="10" />
       <File FileName="DiscordBot/Modules/Utilities/UserInfo.cs" Line="85" Column="54" />
       <File FileName="DiscordBot/Modules/Utilities/UtilityCommands.cs" Line="1" Column="1" />
       <File FileName="DiscordBot/Modules/UserCustomization.cs" Line="11" Column="9" />
+      <File FileName="DiscordBot/Modules/SingleCommands/HelpCommmand.cs" Line="81" Column="133" />
+      <File FileName="DiscordBot/Modules/AdminUtility/AdminUtilities.cs" Line="41" Column="79" />
+      <File FileName="DiscordBot/Modules/AdminUtility/LogHandler.cs" Line="10" Column="9" />
     </Files>
     <Pads>
       <Pad Id="ProjectPad">
@@ -16,10 +17,11 @@
             <Node name="DiscordBot" expanded="True">
               <Node name="Core" expanded="True" />
               <Node name="Modules" expanded="True">
-                <Node name="AdminUtility" expanded="True" />
+                <Node name="AdminUtility" expanded="True">
+                  <Node name="LogHandler.cs" selected="True" />
+                </Node>
                 <Node name="SingleCommands" expanded="True" />
                 <Node name="Utilities" expanded="True" />
-                <Node name="UserCustomization.cs" selected="True" />
               </Node>
             </Node>
           </Node>

--- a/DiscordBot/Core/BotUtils.cs
+++ b/DiscordBot/Core/BotUtils.cs
@@ -49,11 +49,13 @@ namespace DiscordBot.Core
     {
         public string name;
         public string description = "other";
+        public GuildPermission permission;
 
-        public HelpModule(string name, string description)
+        public HelpModule(string name, string description, GuildPermission permission = GuildPermission.SendMessages)
         {
             this.name = name;
             this.description = description;
+            this.permission = permission;
         }
     }
 
@@ -62,12 +64,14 @@ namespace DiscordBot.Core
     {
         public string command;
         public string description;
+        public GuildPermission permission;
 
-        public CommandData(string command, string description = "No command description provided.")
+        public CommandData(string command, string description = "No command description provided.",
+            GuildPermission permission = GuildPermission.SendMessages)
         {
             this.command = command;
             this.description = description;
-
+            this.permission = permission;
         }
     }
 

--- a/DiscordBot/Modules/AdminUtility/AdminUtilities.cs
+++ b/DiscordBot/Modules/AdminUtility/AdminUtilities.cs
@@ -5,10 +5,13 @@ using DiscordBot.Core;
 
 namespace DiscordBot.Modules
 {
+    [InitializeCommands("Admin Utilities")]
+    [HelpModule("Admin Utilities", "Utilities for admins", Discord.GuildPermission.Administrator)]
     public class AdminUtilities : ModuleBase<SocketCommandContext>
     {
         [Command("changeprefix")]
         [Alias("prefix")]
+        [CommandData("prefix <prefix>", "Change the prefix of the bot")]
         [RequireUserPermission(Discord.GuildPermission.Administrator)]
         public async Task ChangePrefix(string prefix)
         {
@@ -24,6 +27,7 @@ namespace DiscordBot.Modules
 
         [Command("stopbot")]
         [Alias("stop")]
+        [CommandData("stopbot", "Disconnects the bot")]
         [RequireUserPermission(Discord.GuildPermission.Administrator)]
         public async Task StopBot()
         {
@@ -35,15 +39,7 @@ namespace DiscordBot.Modules
 
         [Command("changestatus")]
         [Alias("status")]
-        [RequireUserPermission(Discord.GuildPermission.Administrator)]
-        public async Task ChangeStatus()
-        {
-            await ReplyAsync("Unimplemented");
-
-        }
-
-        [Command("changestatus")]
-        [Alias("status")]
+        [CommandData("changestatus <status>", "Change the status of the bot")]
         [RequireUserPermission(Discord.GuildPermission.Administrator)]
         public async Task ChangeStatus(params string[] status)
         {

--- a/DiscordBot/Modules/AdminUtility/LogHandler.cs
+++ b/DiscordBot/Modules/AdminUtility/LogHandler.cs
@@ -7,10 +7,10 @@ using DiscordBot.Core;
 
 namespace DiscordBot.Modules.AdminUtility
 {
+    [InitializeCommands("Admin Utilities")]
     public class LogHandler : ModuleBase<SocketCommandContext>
     {
 
-        private static DiscordSocketClient Client;
         static AdminData adminData;
 
         public static Task InitializeLogHandler(DiscordSocketClient client)
@@ -63,6 +63,7 @@ namespace DiscordBot.Modules.AdminUtility
         }
 
         [Command("logchannel")]
+        [CommandData("logchannel <channel>")]
         [RequireUserPermission(GuildPermission.Administrator)]
         public async Task LogChannel()
         {
@@ -118,6 +119,7 @@ namespace DiscordBot.Modules.AdminUtility
         }
 
         [Command("logging")]
+        [CommandData("logging <true/false>")]
         [RequireUserPermission(GuildPermission.Administrator)]
         public async Task Logging(bool val)
         {
@@ -140,7 +142,7 @@ namespace DiscordBot.Modules.AdminUtility
         {
             if (args[0].Equals("enable", StringComparison.CurrentCultureIgnoreCase)) { await Logging(true); return; }
             if (args[0].Equals("disable", StringComparison.CurrentCultureIgnoreCase)) { await Logging(false); return; }
-            var embed = BotUtils.SuccessEmbed(description: $"Logging is `{(adminData.isLogging ? "enabled" : "disabled")}`",
+            var embed = BotUtils.SuccessEmbed(description: $"Logging is currently `{(adminData.isLogging ? "enabled" : "disabled")}`",
                 withTimestamp: false).Build();
 
             await ReplyAsync(embed: embed);

--- a/DiscordBot/Modules/UserCustomization.cs
+++ b/DiscordBot/Modules/UserCustomization.cs
@@ -5,7 +5,7 @@ using DiscordBot.Core;
 namespace DiscordBot.Modules.SingleCommands
 {
     [InitializeCommands("User Customization")]
-    [HelpModule("User Customizaition", "Commands that allow the user to customize there appearance.")]
+    [HelpModule("User Customization", "Commands that allow the user to customize there appearance.")]
     public class UserCustomization : ModuleBase<SocketCommandContext>
     {
         


### PR DESCRIPTION
Added Help Permissions, [HelpModule] now takes in an optional parameter that determines what GuildPermission the user needs, by default this is set to `GuildPermission.SendMessage`.

User can see commands in a module as long as there is no require permission, or they meet the permission requirement otherwise the command will not show up. 