### PR TITLE
Features/log settings

### DIFF
--- a/.vs/DiscordBot/xs/UserPrefs.xml
+++ b/.vs/DiscordBot/xs/UserPrefs.xml
@@ -1,21 +1,20 @@
 ﻿<Properties StartupConfiguration="{1F84D78C-D248-4DB7-8A19-88CD9A33D51A}|Default">
-  <MonoDevelop.Ide.Workbench ActiveDocument="DiscordBot/Core/Bot.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="DiscordBot/Modules/AdminUtility/LogHandler.cs">
     <Files>
-      <File FileName="DiscordBot/Modules/SingleCommands/HelpCommmand.cs" Line="49" Column="5" />
-      <File FileName="DiscordBot/Core/IModule.cs" Line="1" Column="1" />
-      <File FileName="DiscordBot/Core/ConfigLoader.cs" Line="1" Column="1" />
+      <File FileName="DiscordBot/Core/ConfigLoader.cs" Line="68" Column="1" />
       <File FileName="DiscordBot/Core/Bot.cs" Line="33" Column="44" />
+      <File FileName="DiscordBot/Modules/AdminUtility/LogHandler.cs" Line="1" Column="1" />
     </Files>
     <Pads>
       <Pad Id="ProjectPad">
         <State name="__root__">
           <Node name="DiscordBot" expanded="True">
             <Node name="DiscordBot" expanded="True">
-              <Node name="Core" expanded="True">
-                <Node name="Bot.cs" selected="True" />
-              </Node>
+              <Node name="Core" expanded="True" />
               <Node name="Modules" expanded="True">
-                <Node name="AdminUtility" expanded="True" />
+                <Node name="AdminUtility" expanded="True">
+                  <Node name="LogHandler.cs" selected="True" />
+                </Node>
                 <Node name="SingleCommands" expanded="True" />
                 <Node name="Utilities" expanded="True" />
               </Node>

--- a/DiscordBot/Core/ConfigLoader.cs
+++ b/DiscordBot/Core/ConfigLoader.cs
@@ -63,14 +63,14 @@ namespace DiscordBot.Core
     {
         public ulong logChannelId;
         public bool isLogging = false;
-
+        public LogSettings logSettings = new LogSettings();
     }
 
     [System.Serializable]
     public class LogSettings
     {
-        public bool editMessages = true;
-        public bool deleteMessages = true;
+        public bool editedMessage = true;
+        public bool deletedMessage = true;
     }
 
 }

--- a/DiscordBot/Core/ConfigLoader.cs
+++ b/DiscordBot/Core/ConfigLoader.cs
@@ -69,8 +69,8 @@ namespace DiscordBot.Core
     [System.Serializable]
     public class LogSettings
     {
-        public bool editedMessage = true;
-        public bool deletedMessage = true;
+        public bool editedMessages = true;
+        public bool deletedMessages = true;
     }
 
 }

--- a/DiscordBot/Modules/AdminUtility/LogHandler.cs
+++ b/DiscordBot/Modules/AdminUtility/LogHandler.cs
@@ -26,7 +26,7 @@ namespace DiscordBot.Modules.AdminUtility
 
         private static async Task ClientMessageDeleted(Cacheable<IMessage, ulong> arg1, ISocketMessageChannel arg2)
         {
-            if (!adminData.logSettings.deletedMessage || !adminData.isLogging) return;
+            if (!adminData.logSettings.deletedMessages || !adminData.isLogging) return;
 
             //If the log channel can't be found disable logging
             if((arg2 as SocketGuildChannel).Guild.GetChannel(adminData.logChannelId) == null)
@@ -49,7 +49,7 @@ namespace DiscordBot.Modules.AdminUtility
 
         private static async Task ClientMessageUpdated(Cacheable<IMessage, ulong> arg1, SocketMessage arg2, ISocketMessageChannel arg3)
         {
-            if (!adminData.logSettings.editedMessage || !adminData.isLogging) return;
+            if (!adminData.logSettings.editedMessages || !adminData.isLogging) return;
             if (arg2.Author.IsBot || string.IsNullOrEmpty(arg2.Content)) return;
 
             //If the log channel can't be found disable logging
@@ -87,7 +87,7 @@ namespace DiscordBot.Modules.AdminUtility
 
             ConfigLoader.SaveData(w);
 
-            var embed = BotUtils.SuccessEmbed(description: $"Successfully set log channel to <#{Context.Channel}>", withTimestamp: false).Build();
+            var embed = BotUtils.SuccessEmbed(description: $"Successfully set log channel to <#{Context.Channel.Id}>", withTimestamp: false).Build();
 
             await ReplyAsync(embed: embed);
         }
@@ -102,7 +102,7 @@ namespace DiscordBot.Modules.AdminUtility
 
             ConfigLoader.SaveData(w);
 
-            var embed = BotUtils.SuccessEmbed(description: $"Successfully set log channel to **#{channel}**", withTimestamp: false).Build();
+            var embed = BotUtils.SuccessEmbed(description: $"Successfully set log channel to <#{channel.Id}>", withTimestamp: false).Build();
 
             await ReplyAsync(embed: embed);
         }
@@ -121,7 +121,7 @@ namespace DiscordBot.Modules.AdminUtility
 
                 ConfigLoader.SaveData(w);
 
-                var embed = BotUtils.SuccessEmbed(description: $"Successfully set log channel to #{channel}", withTimestamp: false).Build();
+                var embed = BotUtils.SuccessEmbed(description: $"Successfully set log channel to <#{channel.Id}>", withTimestamp: false).Build();
 
                 await ReplyAsync(embed: embed);
             } catch
@@ -209,7 +209,6 @@ namespace DiscordBot.Modules.AdminUtility
         }
 
         [Command("logsettings")]
-        [CommandData("logsettings <setting> <true/false>", "Turn on or off a log setting")]
         [RequireUserPermission(GuildPermission.Administrator)]
         public async Task LogSettings(string setting, bool val)
         {
@@ -219,6 +218,12 @@ namespace DiscordBot.Modules.AdminUtility
 
             try
             {
+                settings[0].SetValue(adminData.logSettings, val);
+
+                JSONWrapper w = ConfigLoader.LoadData();
+                w.data.adminData.logSettings = adminData.logSettings;
+                ConfigLoader.SaveData(w);
+
                 var embed = BotUtils.SuccessEmbed(description: $"Logging `{settings[0].Name}` set to `{(val ? "true" : "false")}`",
                 withTimestamp: false).Build();
 


### PR DESCRIPTION
Added "Log Settings." Users are now able to change log settings through the bot. Disabling or enabling a setting will determine if the bot logs that settings.
Logging will automatically be disabled when the log can't find the appropriate channel.  

`>logsettings` will list the settings and there values
`>loggsettings <setting> <true/false>` will set a setting 

